### PR TITLE
added support for universal newlines to csv

### DIFF
--- a/simple_import/models.py
+++ b/simple_import/models.py
@@ -154,11 +154,13 @@ class ImportLog(models.Model):
                     break
         elif file_ext == "csv":
             import csv
-            reader = csv.reader(self.import_file)
-            for row in reader:
-                data += [row]
-                if only_header:
-                    break
+            # open with universal newline support
+            with open(self.import_file.path, 'rU') as f:
+                reader = csv.reader(f)
+                for row in reader:
+                    data += [row]
+                    if only_header:
+                        break
         elif file_ext == "lsx":
             from openpyxl.reader.excel import load_workbook
             # load_workbook actually accepts a file-like object for the filename param


### PR DESCRIPTION
What i did here was specify 'U' mode for reading the csv.  It worked for my particular situation, but i don't know if there are any further implications.  Not sure if this implementation is compatible with other file backends, for example, or whether there is a more elegant solution.  In the latest development branch of Django, it appears that universal newline support is supported by default, although i don't have the reference.
