### PR TITLE
strip cell value

### DIFF
--- a/simple_import/views.py
+++ b/simple_import/views.py
@@ -283,6 +283,7 @@ def set_field_from_cell(import_log, new_object, header_row_field_name, cell):
     """ Set a field from a import cell. Use referenced fields the field
     is m2m or a foreign key.
     """
+    cell = cell.strip()
     if (not header_row_field_name.startswith('simple_import_custom__') and
             not header_row_field_name.startswith('simple_import_method__')):
         field, model, direct, m2m =  new_object._meta.get_field_by_name(header_row_field_name)


### PR DESCRIPTION
Any opposition to this?  i had a file where each value had an extra space at the end, and as a consequence, it wasn't matching the field.choices.
