### PR TITLE
strip cell value before attempting a choices match

### DIFF
--- a/simple_import/views.py
+++ b/simple_import/views.py
@@ -294,6 +294,8 @@ def set_field_from_cell(import_log, new_object, header_row_field_name, cell):
             related_object = related_model.objects.get(**{related_field_name:cell})
             setattr(new_object, header_row_field_name, related_object)
         elif field.choices and getattr(settings, 'SIMPLE_IMPORT_LAZY_CHOICES', True):
+            # trim any whitespace from the value
+            cell = cell.strip()
             # Prefer database values over choices lookup
             database_values, verbose_values = zip(*field.choices)
             if cell in database_values:


### PR DESCRIPTION
This would fix matches for values which have leading or trailing whitespace in the excel file, without interfering with leading/trailing whitespace in the value for other cases.
