### PR TITLE
alternate to #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ SIMPLE_IMPORT_LAZY_CHOICES: Default True. If enabled simple_import will look up 
 
 If the spreadsheet value is "Monday" it will set the database value to "M."
 
+SIMPLE_IMPORT_LAZY_CHOICES_STRIP: Default False.  If enabled, simple_import will trip leading/trailing whitespace 
+from the cell's value before checking for a match.  Only relevant when SIMPLE_IMPORT_LAZY_CHOICES is also enabled.
+ 
 If you need any help, we do consulting and custom development. Just email us at david at burkesoftware.com.
 
 

--- a/simple_import/views.py
+++ b/simple_import/views.py
@@ -294,6 +294,9 @@ def set_field_from_cell(import_log, new_object, header_row_field_name, cell):
             related_object = related_model.objects.get(**{related_field_name:cell})
             setattr(new_object, header_row_field_name, related_object)
         elif field.choices and getattr(settings, 'SIMPLE_IMPORT_LAZY_CHOICES', True):
+            # Trim leading and trailing whitespace from cell values
+            if getattr(settings, 'SIMPLE_IMPORT_LAZY_CHOICES_STRIP', False):
+                cell = cell.strip()
             # Prefer database values over choices lookup
             database_values, verbose_values = zip(*field.choices)
             if cell in database_values:


### PR DESCRIPTION
Added SIMPLE_IMPORT_LAZY_CHOICES_STRIP.  Default setting (False) preserves original behavior.

If enabled, simple_import will trip leading/trailing whitespace from the cell's value before checking for a match.  Only relevant when SIMPLE_IMPORT_LAZY_CHOICES is also enabled.
